### PR TITLE
 Less strict version requirements for Requests

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -5,11 +5,11 @@ mock==2.0.0
 nose==1.3.7
 python-coveralls==2.9.0
 responses==0.5.1
-requests==2.13.0
+requests~=2.13.0
 six==1.10.0
 Sphinx==1.5.3
 sphinx-rtd-theme==0.2.4
 tox==2.6.0
 virtualenv==15.1.0
 watchdog==0.8.3
-wheel==0.24.0
+wheel=0.24.0

--- a/requirements.pip
+++ b/requirements.pip
@@ -12,4 +12,4 @@ sphinx-rtd-theme==0.2.4
 tox==2.6.0
 virtualenv==15.1.0
 watchdog==0.8.3
-wheel=0.24.0
+wheel==0.24.0


### PR DESCRIPTION
Using the `~=` operator allows the use of any feature-compatible versions of Requests released after 2.13.0.

This prevents `pip install wiremock` from forcibly downgrading Requests during install.

(See [PEP 440: Compatible release](python.org/dev/peps/pep-0440/#compatible-release))