### PR TITLE
Add imports to quickstart example

### DIFF
--- a/docs/server_cm.py
+++ b/docs/server_cm.py
@@ -1,3 +1,7 @@
+from wiremock.constants import Config
+from wiremock.client import *
+from wiremock.server.server import WireMockServer
+
 with WireMockServer() as wm:
     Config.base_url = 'http://localhost:{}/__admin'.format(wm.port)
     Mappings.create_mapping(...)  # Set up stubs


### PR DESCRIPTION
This Quickstart example missed the necessary import `from wiremock.server.server import WireMockServer` which, as a first-time user, is difficult to know about.
Added other wiremock imports as well for completeness.