### PR TITLE
Set correct branch for github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Python Testing
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build:
@@ -12,21 +12,23 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+        run: curl -sSL https://install.python-poetry.org | python
 
       - name: Install dependencies
-        run: poetry install
+        run: |
+          poetry env use ${{matrix.python-version}}
+          poetry install
 
-      - name: Run tests with pytest
-        run: tox -e py${{ matrix.python-version/./ }}-pytest
+      - name: Test with pytest
+        run: |
+          poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -344,6 +344,25 @@ perf = ["ipython"]
 testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
+name = "importlib-resources"
+version = "5.12.0"
+description = "Read resources from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "importlib_resources-5.12.0-py3-none-any.whl", hash = "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"},
+    {file = "importlib_resources-5.12.0.tar.gz", hash = "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"},
+]
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -844,7 +863,7 @@ test = ["pytest (>=6.0.0)"]
 name = "zipp"
 version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -859,4 +878,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7 | ^3.8 | ^3.9 | ^3.10 | ^3.11"  
-content-hash = "e28cb61eb7f26a64c340123182ca52f422b0467739aa5fe1f1fc0cf9aa6683a4"
+content-hash = "d3f2f63f578574ac4285bea3f27c46ebfdf24d1adbe9eb6be4d99b08c4498294"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers=[
 [tool.poetry.dependencies]
 python = "^3.7 | ^3.8 | ^3.9 | ^3.10 | ^3.11"  
 requests = "^2.20.0"
+importlib-resources = "^5.12.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/tests/test_server/test_server.py
+++ b/tests/test_server/test_server.py
@@ -1,10 +1,10 @@
-import importlib
 from dataclasses import dataclass
 from subprocess import PIPE, STDOUT
 from unittest.mock import DEFAULT, patch
 
 import pytest
 import responses
+from importlib_resources import files
 
 from tests.utils import assertEqual, assertIsInstance
 from wiremock.server.exceptions import (
@@ -54,11 +54,7 @@ def test_init_with_defaults(config):
     with patch.object(WireMockServer, "_get_free_port", return_value=config.port):
         wm = WireMockServer()
 
-    expected_jar = (
-        importlib.resources.files("wiremock")
-        / "server"
-        / "wiremock-standalone-2.6.0.jar"
-    )
+    expected_jar = files("wiremock") / "server" / "wiremock-standalone-2.6.0.jar"
     assertEqual(wm.java_path, "java")  # Assume java in PATH
     assertEqual(wm.jar_path, expected_jar)
 

--- a/wiremock/server/server.py
+++ b/wiremock/server/server.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 """WireMock Server Management."""
 import atexit
-import importlib.resources
 import socket
 import time
 from subprocess import PIPE, STDOUT, Popen
 
 import requests
+from importlib_resources import files
 
 from wiremock.server.exceptions import (
     WireMockServerAlreadyStartedError,
@@ -17,11 +17,7 @@ from wiremock.server.exceptions import (
 class WireMockServer(object):
 
     DEFAULT_JAVA = "java"  # Assume java in PATH
-    DEFAULT_JAR = (
-        importlib.resources.files("wiremock")
-        / "server"
-        / "wiremock-standalone-2.6.0.jar"
-    )
+    DEFAULT_JAR = files("wiremock") / "server" / "wiremock-standalone-2.6.0.jar"
 
     def __init__(
         self,


### PR DESCRIPTION
Noticed that the github actions branch matching for the github actions added in the last pr were matching against main and not master.

Whilst getting the actions running against python 3.7, 3.8 i discovered a bug which this pr also resolves in this commit 
https://github.com/wiremock/python-wiremock/pull/60/commits/34c23c1db948938364d0e843c9af9ff82a844425

Relates To: https://github.com/wiremock/python-wiremock/issues/55