### PR TITLE
Remove detox from the PIP declaration

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,6 +1,5 @@
 black==19.10b0
 coverage==5.0.3
-detox==0.19
 docutils==0.16
 mock==4.0.1
 nose==1.3.7


### PR DESCRIPTION
It is obsolete: https://pypi.org/project/detox/

> detox was a plugin for [tox](https://pypi.org/project/tox/) to enable parallel environment execution. tox 3.7 added a native possibility to do this (tox -p|--parallel) and effectively supercedes detox.