### PR TITLE
Remove Funding links from the repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: [platinummonkey]
-custom: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=UV978FNAYLYZE&item_name=Github+Donations&currency_code=USD&source=url


### PR DESCRIPTION
As discussed with @platinummonkey a while ago, I would like to remove the funding metadata.