### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Then use your favorite IDE for development and testing.
 ## Contributing examples
 
 Please submit new examples as a pull requests to the
-[examples directory]([./examples/](https://github.com/wiremock/python-wiremock/tree/master/examples)).
+[examples directory](https://github.com/wiremock/python-wiremock/tree/master/examples). 
 You can also also add links to external examples and tutorials to the `README.md`
 file in the directory.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -98,4 +98,4 @@ You can read more about Testcontainers support in Python WireMock [here](./testc
 
 ## More examples
 
-See [this page](..) for more example references
+See [this page](./examples.md) for more example references


### PR DESCRIPTION
This PR fixes two broken links in the documentation.

## References

- (none)

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [?] The PR title represents the desired changelog entry
- [-] The repository's code style is followed (see the contributing guide)
- [-] Test coverage that demonstrates that the change works as expected
- [-] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [x] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
