### PR TITLE
draft: generate reference documentation using mkdosctrings

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,6 @@
+This part of the project documentation focuses on
+an **information-oriented** approach. Use it as a
+reference for the technical implementation of the
+`python-wiremock` project code.
+
+::: wiremock

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,11 @@ theme:
   highlightjs: true
 plugins:
   - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_submodules: true
 markdown_extensions:
   - markdown_include.include:
       base_path: .
@@ -15,6 +20,7 @@ nav:
   - Installation: install.md
   - Testcontainers: testcontainers.md
   - Standalone: api-client.md
+  - Reference: reference.md
   - Contributing: CONTRIBUTING.md
   - Resources:
     - Examples: examples.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,13 @@ classifiers=[
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7 | ^3.8 | ^3.9 | ^3.10 | ^3.11"  
+python = "^3.8 | ^3.9 | ^3.10 | ^3.11"
 requests = "^2.20.0"
 importlib-resources = "^5.12.0"
 docker = {version = "^6.1.0", optional = true}
 testcontainers = {version = "^3.7.1", optional = true}
+mkdocstrings-python = "^1.3.0"
+mkdocs-material = "^9.1.21"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"

--- a/wiremock/base/base_entity.py
+++ b/wiremock/base/base_entity.py
@@ -1,3 +1,5 @@
+"""This is example module docstring content for documentation development"""
+
 from collections import OrderedDict
 import json
 

--- a/wiremock/client.py
+++ b/wiremock/client.py
@@ -1,3 +1,5 @@
+"""This is test docstring content for documentation development"""
+
 # import Exceptions
 from .exceptions import *
 


### PR DESCRIPTION
This draft PR shows my work so far on automatically generating a reference section of the documentation based on docstrings in the source code.

I find that `mkdosctrings` may not be a sufficient tool for this task because it seems more optimized towards documenting individual functions or modules, rather than a full library. I will continue to research and try to understand how projects like interactions.py and Serenity generate their documentation.

Note: I adjusted the available Python versions for compatibility with the new documentation dependencies. I understand this may pose an issue.

## References

- [interactions.py API reference](https://interactions-py.github.io/interactions.py/API%20Reference/API%20Reference/Client/)
- [Serenity documentation](https://docs.rs/serenity/latest/serenity/)



## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [?] The PR title represents the desired changelog entry
- [-] The repository's code style is followed (see the contributing guide)
- [-] Test coverage that demonstrates that the change works as expected
- [-] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [x] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
