### PR TITLE
Change the return type of `create_mapping()` from `MappingResponse` to `Mapping`

### DIFF
--- a/tests/test_resources/test_mapping/test_mapping_resource.py
+++ b/tests/test_resources/test_mapping/test_mapping_resource.py
@@ -16,22 +16,24 @@ from wiremock.client import (
 @pytest.mark.resource
 @responses.activate
 def test_create_mapping():
-    e = MappingResponse(body="test", status=200)
-    resp = e.get_json_data()
-    responses.add(
-        responses.POST, "http://localhost/__admin/mappings", json=resp, status=200
-    )
-
     m = Mapping(
         priority=1,
         request=MappingRequest(url="test", method="GET"),
         response=MappingResponse(status=200, body="test"),
     )
 
+    e = Mapping(**m, id="1234-5678")
+    resp = e.get_json_data()
+    responses.add(
+        responses.POST, "http://localhost/__admin/mappings", json=resp, status=200
+    )
+
     r = Mappings.create_mapping(m)
-    assert isinstance(r, MappingResponse)
-    assert r.status == 200
-    assert r.body == "test"
+    assert isinstance(r, Mapping)
+    assert r.id == "1234-5678"
+    assert r.priority == 1
+    assert r.request == m.request
+    assert r.response == m.response
 
 
 @pytest.mark.unit

--- a/wiremock/resources/mappings/resource.py
+++ b/wiremock/resources/mappings/resource.py
@@ -30,7 +30,7 @@ class Mappings(BaseResource):
             params=parameters,
         )
         response = cls.REST_CLIENT.handle_response(response)
-        return MappingResponse.from_dict(response.json())
+        return Mapping.from_dict(response.json())
 
     @classmethod
     def retrieve_all_mappings(cls, parameters={}):


### PR DESCRIPTION
I am not too familiar with this library or WireMock, however I need to create a mapping and remember its ID so I can delete it later. It turns out that the object returned by create_mapping is a `MappingResponse` full of None values and there is no `id` property at all.

This PR changes the return type to `Mapping`, which seems to be what the WireMock server actually returns. `MappingResponse` is just the type of the `response` property in `Mapping`.

The existing unit test did not catch the bug because the mocked response was already wrong to begin with. Weirdly enough this bug has existed since the initial commit.

I did not add any integration tests because I could not get them to work. Integration tests are also failing in CI.