### PR TITLE
Fix `--root-dir` propagation to the standalone server

### DIFF
--- a/wiremock/server/server.py
+++ b/wiremock/server/server.py
@@ -61,7 +61,7 @@ class WireMockServer(object):
             "--local-response-templating",
         ]
         if self.root_dir is not None:
-            cmd.append("--root-dir=")
+            cmd.append("--root-dir")
             cmd.append(str(self.root_dir))
         try:
             self.__subprocess = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=STDOUT)


### PR DESCRIPTION
Closes https://github.com/wiremock/python-wiremock/issues/100 & https://github.com/wiremock/python-wiremock/issues/96

## References


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [ ] Recommended: If you participate in Hacktoberfest 2023, make sure you're [signed up](https://wiremock.org/events/hacktoberfest/) there and in the WireMock form 
- [ x] The PR request is well described and justified, including the body and the references
- [ x] The PR title represents the desired changelog entry
- [ x] The repository's code style is followed (see the contributing guide)
- [ x] Test coverage that demonstrates that the change works as expected
- [ x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
