### PR TITLE
Increase retry_count for server_running to 10 to account for slower startup times of Wiremock

### DIFF
--- a/wiremock/testing/testcontainer.py
+++ b/wiremock/testing/testcontainer.py
@@ -143,7 +143,7 @@ class WireMockContainer(DockerContainer):
             configs=self.mapping_files, container_dir_path=Path(f"{self.FILES_DIR}")
         )
 
-    def server_running(self, retry_count: int = 3, retry_delay: int = 1) -> bool:
+    def server_running(self, retry_count: int = 10, retry_delay: int = 1) -> bool:
         """Pings the __admin/mappings endpoint of the wiremock server running inside the
         container as a proxy for checking if the server is up and running.
 


### PR DESCRIPTION
I am using python-wiremock in a project I'm working on. When running with docker-desktop it works fine, but when I switch to colima as the host it appears that it takes slightly longer for the Wiremock server to get ready in the container. I'm running on an M2 Mac.

This is the error I get:

```
Waiting for container <Container: da6d6427c7f6> with image wiremock/wiremock:2.35.1-1 to be ready ...
Waiting for container <Container: da6d6427c7f6> with image wiremock/wiremock:2.35.1-1 to be ready ...
Request failed: HTTPConnectionPool(host='localhost', port=32847): Max retries exceeded with url: /__admin/mappings (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10dc21be0>: Failed to establish a new connection: [Errno 61] Connection refused'))
Waiting for container <Container: da6d6427c7f6> with image wiremock/wiremock:2.35.1-1 to be ready ...
Request failed: HTTPConnectionPool(host='localhost', port=32847): Max retries exceeded with url: /__admin/mappings (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10dc70550>: Failed to establish a new connection: [Errno 61] Connection refused'))
Waiting for container <Container: da6d6427c7f6> with image wiremock/wiremock:2.35.1-1 to be ready ...
Request failed: HTTPConnectionPool(host='localhost', port=32847): Max retries exceeded with url: /__admin/mappings (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x10dc70a50>: Failed to establish a new connection: [Errno 61] Connection refused'))
ERROR                                                                                                                                                                                                                                                      [ 21%]
```

If I go in to the `server_running` function in python-wiremock and manually bump up the `retry_count` to 10 (as per this PR) then it works fine, on the 4th attempt it successfully connects to wiremock.

I think a cleaner solution to my problem would be if we could expose the `retry_count` as configuration, but I don't have the time to contribute such a major change at the moment. This would solve my problem in the short term, at least.

## References

No relevant references

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)