### PR TITLE
Revert WireMock v3-related changes

### DIFF
--- a/tests/test_resources/test_requests/test_requests_resource.py
+++ b/tests/test_resources/test_requests/test_requests_resource.py
@@ -58,7 +58,7 @@ def test_get_request():
 @responses.activate
 def test_reset_request_journal():
     responses.add(
-        responses.DELETE, "http://localhost/__admin/requests", body="", status=200
+        responses.POST, "http://localhost/__admin/requests/reset", body="", status=200
     )
 
     r = Requests.reset_request_journal()

--- a/wiremock/resources/requests/resource.py
+++ b/wiremock/resources/requests/resource.py
@@ -47,7 +47,7 @@ class Requests(BaseResource):
     @classmethod
     def reset_request_journal(cls, parameters={}):
         ids = {"id": "reset"}
-        response = cls.REST_CLIENT.delete(cls.get_base_uri(cls.endpoint()), headers=make_headers(), params=parameters)
+        response = cls.REST_CLIENT.post(cls.get_base_uri(cls.endpoint_single(), **ids), headers=make_headers(), params=parameters)
         return cls.REST_CLIENT.handle_response(response)
 
     @classmethod


### PR DESCRIPTION
Revert the changes introduced in the master branch by https://github.com/wiremock/python-wiremock/pull/108. For now, we will leave the master branch only for WireMock v2. These changes should be picked up by the v3 branch.

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)