### PR TITLE
Fix unit tests runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/examples/intro/Dockerfile
+++ b/examples/intro/Dockerfile
@@ -1,5 +1,5 @@
 # vim: set filetype=Dockerfile:
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 ENV POETRY_HOME="/opt/poetry" \
     POETRY_VIRTUALENVS_CREATE=false \


### PR DESCRIPTION
The unit test runner is broken for Python 3.7 because the latest Ubuntu version (`24.04`), which we are using, does not include Python 3.7.
The integration test runner was also broken because it used a legacy Python base image (`3.11-slim-buster`). I have updated it to use `3.11-slim-bookworm` instead.

Until we drop support for 3.7, I have pinned the Ubuntu version to `22.04` to keep the runner working.

Also, updated `setup-python` action to the latest version