### PR TITLE
feat(mappings): urlPathPattern is added

### DIFF
--- a/tests/test_resources/test_mapping/test_mapping_serialization.py
+++ b/tests/test_resources/test_mapping/test_mapping_serialization.py
@@ -102,6 +102,7 @@ def test_mapping_request_serialization():
         url_path="test2",
         url_path_pattern="test3",
         url_pattern="test4",
+        url_path_template="test5",
         basic_auth_credentials=BasicAuthCredentials(
             username="username", password="password"
         ),
@@ -117,6 +118,7 @@ def test_mapping_request_serialization():
     assert serialized["urlPath"] == "test2"
     assert serialized["urlPathPattern"] == "test3"
     assert serialized["urlPattern"] == "test4"
+    assert serialized["urlPathTemplate"] == "test5"
     assert serialized["basicAuthCredentials"] == {
         "username": "username",
         "password": "password",
@@ -139,6 +141,7 @@ def test_mapping_request_deserialization():
         "urlPath": "test2",
         "urlPathPattern": "test3",
         "urlPattern": "test4",
+        "urlPathTemplate": "test5",
         "basicAuthCredentials": {
             "username": "username",
             "password": "password",
@@ -156,6 +159,7 @@ def test_mapping_request_deserialization():
     assert "test2" == e.url_path
     assert "test3" == e.url_path_pattern
     assert "test4" == e.url_pattern
+    assert "test5" == e.url_path_template
     assert isinstance(e.basic_auth_credentials, BasicAuthCredentials)
     assert "username" == e.basic_auth_credentials.username
     assert "password" == e.basic_auth_credentials.password

--- a/wiremock/resources/mappings/models.py
+++ b/wiremock/resources/mappings/models.py
@@ -127,6 +127,7 @@ class MappingRequest(BaseAbstractEntity):
     method = JsonProperty("method")
     url = JsonProperty("url")
     url_path = JsonProperty("urlPath")
+    url_path_template= JsonProperty("urlPathTemplate")
     url_path_pattern = JsonProperty("urlPathPattern")
     url_pattern = JsonProperty("urlPattern")
     basic_auth_credentials = JsonProperty(

--- a/wiremock/resources/mappings/models.py
+++ b/wiremock/resources/mappings/models.py
@@ -127,9 +127,9 @@ class MappingRequest(BaseAbstractEntity):
     method = JsonProperty("method")
     url = JsonProperty("url")
     url_path = JsonProperty("urlPath")
-    url_path_template= JsonProperty("urlPathTemplate")
     url_path_pattern = JsonProperty("urlPathPattern")
     url_pattern = JsonProperty("urlPattern")
+    url_path_template= JsonProperty("urlPathTemplate")
     basic_auth_credentials = JsonProperty(
         "basicAuthCredentials", klass=BasicAuthCredentials
     )


### PR DESCRIPTION
This PR adds a new/missing parameter `urlPathPattern` for Mapping resource. 

## References

https://wiremock.org/docs/request-matching/#regex-matching-on-the-path-only

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
