### PR TITLE
feat(scenario): change_scenario_state method is added

### DIFF
--- a/wiremock/resources/scenarios/resource.py
+++ b/wiremock/resources/scenarios/resource.py
@@ -20,5 +20,14 @@ class Scenarios(BaseResource):
         response = cls.REST_CLIENT.post(cls.get_base_uri(cls.endpoint()), headers=make_headers(), params=parameters)
         return cls.REST_CLIENT.handle_response(response)
 
+    @classmethod
+    def change_scenario_state(cls, scenario_name, state):
+        response = cls.REST_CLIENT.put(
+            cls.get_base_uri(f"{cls.endpoint_single()}/{scenario_name}/state"),
+            headers=make_headers(),
+            json={"state": state},
+        )
+        return cls.REST_CLIENT.handle_response(response)
+
 
 __all__ = ["Scenarios"]


### PR DESCRIPTION
This PR adds a new function to change scenario state. 

## References

https://wiremock.org/docs/stateful-behaviour/#setting-the-state-of-an-individual-scenario

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
